### PR TITLE
Fixed order state not saved on notification in 1.8.1.0

### DIFF
--- a/app/code/community/Quadra/Cybermut/controllers/PaymentController.php
+++ b/app/code/community/Quadra/Cybermut/controllers/PaymentController.php
@@ -184,12 +184,11 @@ class Quadra_Cybermut_PaymentController extends Mage_Core_Controller_Front_Actio
                         }
                         $order->addStatusToHistory($status, $message, true);
                     }
+                    $order->save();
 
                     if (!$order->getEmailSent()) {
                         $order->sendNewOrderEmail();
                     }
-
-                    $order->save();
                 }
             } else {
                 foreach ($this->getRealOrderIds() as $realOrderId) {


### PR DESCRIPTION
... on payment notifications the order state
(and other changes) are not persisted with Magento
1.8.1.0 because `sendNewOrderEmail()` will reload
all data in the `$order` object

See [our blog post](http://blog.occitech.fr/2014/01/magento-1-8-1-0-changements-sur-lenvoi-demail-de-confirmation-de-commande) (in French) for further details.
