### PR TITLE
V3 Plain key support + Patch bugs + Modman + Test restrictions to IP List

### DIFF
--- a/app/code/community/Quadra/Cybermut/Block/Redirect.php
+++ b/app/code/community/Quadra/Cybermut/Block/Redirect.php
@@ -38,7 +38,7 @@ class Quadra_Cybermut_Block_Redirect extends Mage_Core_Block_Abstract
         $html.= '<script type="text/javascript">document.getElementById("cybermut_payment_checkout").submit();</script>';
         $html.= '</body></html>';
 
-        if ($methodInstance->getConfigData('debug_flag')) {
+        if ($methodInstance->isDebugModeActivated()) {
             Mage::getModel('cybermut/api_debug')
                     ->setRequestBody($formHTML)
                     ->save();

--- a/app/code/community/Quadra/Cybermut/Model/Abstract.php
+++ b/app/code/community/Quadra/Cybermut/Model/Abstract.php
@@ -339,6 +339,18 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
     }
 
     /**
+     *  Return decrypted merchant security key
+     *
+     *  @param    none
+     *  @return	  string Decrypted merchant security key
+     */
+    protected function _getSecurityKey()
+    {
+    		$key = trim( $this->getConfigData('security_key') );
+    		return Mage::helper('core')->decrypt( $key );
+    }
+    
+    /**
      *  Return merchant key
      *
      *  @param    none
@@ -355,21 +367,17 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
      *  @param    none
      *  @return	  string encrypted key
      */
-    /* protected function _getKeyEncrypted()
-      {
-      $key = $this->getConfigData('key_encrypted');
-      $key = Mage::helper('core')->decrypt($key);
-
-      $avant_dernier_tranforme = (ord(substr($key, strlen($key) - 2, 1)) - 23);
-      $key = substr($key, 0, strlen($key) - 2) . chr($avant_dernier_tranforme) . substr($key, strlen($key) - 1, 1);
-
-      return pack("H*", $key);
-      } */
-
     protected function _getKeyEncrypted()
     {
+    		// V3
+		$key = $this->_getSecurityKey();
+	    	
+		// < V3
+	    	// Load from file if key is empty
+		if (empty( $key )) {
         $key = $this->getConfigData('key_encrypted');
         $key = Mage::helper('core')->decrypt($key);
+		}
 
         $hexStrKey = substr($key, 0, 38);
         $hexFinal = "" . substr($key, 38, 2) . "00";

--- a/app/code/community/Quadra/Cybermut/Model/Abstract.php
+++ b/app/code/community/Quadra/Cybermut/Model/Abstract.php
@@ -48,7 +48,7 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
 
         return $version;
     }
-
+    
     /**
      *  Return Test Mode IP List
      *
@@ -412,7 +412,7 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
                 $data['pares'] = "";
             }
 
-            $string = sprintf('%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*', $data['TPE'], $data['date'], $data['montant'], $data['reference'], $data['texte-libre'], '3.0', $data['code-retour'], $data['cvx'], $data['vld'], $data['brand'], $data['status3ds'], $data['numauto'], $data['motifrefus'], $data['originecb'], $data['bincb'], $data['hpancb'], $data['ipclient'], $data['originetr'], $data['veres'], $data['pares']);
+            $string = sprintf('%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*%s*', $data['TPE'], $data['date'], $data['montant'], $data['reference'], $data['texte-libre'], $this->getVersion(), $data['code-retour'], $data['cvx'], $data['vld'], $data['brand'], $data['status3ds'], $data['numauto'], $data['motifrefus'], $data['originecb'], $data['bincb'], $data['hpancb'], $data['ipclient'], $data['originetr'], $data['veres'], $data['pares']);
         } else {
             $string = sprintf('%s%s+%s+%s+%s+%s+%s+%s+', $data['retourPLUS'], $data['TPE'], $data['date'], $data['montant'], $data['reference'], $data['texte-libre'], $this->getVersion(), $data['code-retour']);
         }

--- a/app/code/community/Quadra/Cybermut/Model/Abstract.php
+++ b/app/code/community/Quadra/Cybermut/Model/Abstract.php
@@ -211,7 +211,7 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
 
         $fields = array(
             'version' => $this->getVersion(),
-            'TPE' => $this->getConfigData('tpe_no'),
+            'TPE' => trim( $this->getConfigData('tpe_no') ),
             'date' => date('d/m/Y:H:i:s'),
             'montant' => $this->getAmount() . $order->getBaseCurrencyCode(),
             'reference' => $this->getOrderList(),
@@ -248,7 +248,7 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
         $description = $this->getConfigData('description') ? $this->getConfigData('description') : Mage::helper('cybermut')->__('Order %s', $order->getRealOrderId());
 
         $get['retourPLUS'] = "--no-option";
-        $get['TPE'] = $this->getConfigData('tpe_no');
+        $get['TPE'] = trim( $this->getConfigData('tpe_no') );
         $get['date'] = date('d/m/Y:H:i:s');
         $get['montant'] = sprintf('%.2f', $order->getBaseGrandTotal()) . $order->getBaseCurrencyCode();
         $get['reference'] = $order->getRealOrderId();
@@ -256,7 +256,7 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
         $get['code-retour'] = $code_retour;
 
         return "?MAC=" . $this->getResponseMAC($get)
-                . "&TPE=" . $this->getConfigData('tpe_no')
+                . "&TPE=" . trim( $this->getConfigData('tpe_no') )
                 . "&date=" . date('d/m/Y:H:i:s')
                 . "&montant=" . sprintf('%.2f', $order->getBaseGrandTotal()) . $order->getBaseCurrencyCode()
                 . "&reference=" . $order->getRealOrderId()
@@ -375,8 +375,8 @@ abstract class Quadra_Cybermut_Model_Abstract extends Mage_Payment_Model_Method_
 		// < V3
 	    	// Load from file if key is empty
 		if (empty( $key )) {
-        $key = $this->getConfigData('key_encrypted');
-        $key = Mage::helper('core')->decrypt($key);
+	        $key = $this->getConfigData('key_encrypted');
+	        $key = Mage::helper('core')->decrypt( $key );
 		}
 
         $hexStrKey = substr($key, 0, 38);

--- a/app/code/community/Quadra/Cybermut/Model/System/Config/Backend/Keyencrypted.php
+++ b/app/code/community/Quadra/Cybermut/Model/System/Config/Backend/Keyencrypted.php
@@ -23,8 +23,26 @@ class Quadra_Cybermut_Model_System_Config_Backend_Keyencrypted extends Mage_Core
      */
     protected function _beforeSave()
     {
+    		switch ( $this->getPath() ) {
+    			
+    			case 'payment/cybermut_payment/key_encrypted' :
+    				if (isset( $_POST['groups']['cybermut_payment']['fields']['key_encrypted']['value']['delete'] )
+	    				&& $_POST['groups']['cybermut_payment']['fields']['key_encrypted']['value']['delete'] )
+    					$this->setValue('');
+    				break;
+    				
+    			case 'payment/cybermut_several/key_encrypted' :
+    				if (isset ( $_POST['groups']['cybermut_several']['fields']['key_encrypted']['value']['delete'] )
+    					&& $_POST['groups']['cybermut_several']['fields']['key_encrypted']['value']['delete'] )
+    					$this->setValue('');
+    				break;
+    		}		
+    
         if ($path = $_FILES['groups']['tmp_name']['cybermut_payment']['fields']['key_encrypted']['value']) {
-
+        	
+        		if (is_array( $path ) )
+        			$path = $path['value'];
+        		
             $filecontent = file_get_contents($path);
             @unlink($path);
 

--- a/app/code/community/Quadra/Cybermut/Model/System/Config/Source/Version.php
+++ b/app/code/community/Quadra/Cybermut/Model/System/Config/Source/Version.php
@@ -33,6 +33,10 @@ class Quadra_Cybermut_Model_System_Config_Source_Version
             'value' => '3.0',
             'label' => '3.0'
         );
+        $options[] = array(
+        		'value' => '4.0',
+        		'label' => '4.0'
+        );
 
         return $options;
     }

--- a/app/code/community/Quadra/Cybermut/Model/System/Config/Source/Version.php
+++ b/app/code/community/Quadra/Cybermut/Model/System/Config/Source/Version.php
@@ -35,7 +35,7 @@ class Quadra_Cybermut_Model_System_Config_Source_Version
         );
         $options[] = array(
         		'value' => '4.0',
-        		'label' => '4.0'
+        		'label' => Mage::helper('adminhtml')->__('4.0 (Not released under production yet)')
         );
 
         return $options;

--- a/app/code/community/Quadra/Cybermut/etc/system.xml
+++ b/app/code/community/Quadra/Cybermut/etc/system.xml
@@ -126,7 +126,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </test_mode>
-                        <debug translate="label">
+                        <debug_flag translate="label">
                             <label>Debug</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
@@ -134,7 +134,16 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </debug>
+                        </debug_flag>
+                        <test_mode_ip_list translate="label">
+                            <label>Test/Debug mode IP List</label>
+                            <comment>Test/Debug mode will be restricted to these IP (IPv4 or IPv6)</comment>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>115</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </test_mode_ip_list>
                         <order_status translate="label">
                             <label>New order status</label>
                             <frontend_type>select</frontend_type>
@@ -334,7 +343,7 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </test_mode>
-                        <debug translate="label">
+                        <debug_flag translate="label">
                             <label>Debug</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
@@ -342,7 +351,16 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </debug>
+                        </debug_flag>
+                        <test_mode_ip_list translate="label">
+                            <label>Test/Debug mode IP List</label>
+                            <comment>Test/Debug mode will be restricted to these IP (IPv4 or IPv6)</comment>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>115</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </test_mode_ip_list>
                         <order_status translate="label">
                             <label>New order status</label>
                             <frontend_type>select</frontend_type>

--- a/app/code/community/Quadra/Cybermut/etc/system.xml
+++ b/app/code/community/Quadra/Cybermut/etc/system.xml
@@ -70,6 +70,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </site_code>
+                        <security_key translate="label">
+                            <label>Security key</label>
+                            <comment>Security key is priority on file key. Please keep it empty to use file key so.</comment>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+                            <sort_order>55</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </security_key>
                         <key_encrypted translate="label">
                             <label>Key</label>
                             <frontend_type>file</frontend_type>
@@ -258,6 +268,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </site_code>
+                        <security_key translate="label">
+                            <label>Security key</label>
+                            <comment>Security key is priority on file key. Please keep it empty to use file key so.</comment>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+                            <sort_order>55</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </security_key>
                         <key_encrypted translate="label">
                             <label>Key</label>
                             <frontend_type>file</frontend_type>

--- a/app/etc/modules/Quadra_Cybermut.xml
+++ b/app/etc/modules/Quadra_Cybermut.xml
@@ -22,7 +22,7 @@
             <codePool>community</codePool>
             <depends>
                 <Mage_Payment />
-                <Quadra_Extensions />
+                <!-- Quadra_Extensions /-->
             </depends>
         </Quadra_Cybermut>
     </modules>

--- a/app/locale/fr_FR/Quadra_Cybermut.csv
+++ b/app/locale/fr_FR/Quadra_Cybermut.csv
@@ -53,3 +53,5 @@
 "Only if several times payment is enabled","Seulement si les paiement en plusieurs fois est activé"
 "Order number will be used if left empty","Le numéro de commande sera utilisé par défaut"
 "Preference will be given to store language chosen by the user","La préférence sera donnée à la langue du magasin choisi par l'utilisateur"
+"Security key","Clé de sécurité"
+"Security key is priority on file key. Please keep it empty to use file key so.","La clé de sécurité est prioritaire sur la clé fichier. Veuillez donc conserver ce champ vide pour utiliser la clé fichier"

--- a/app/locale/fr_FR/Quadra_Cybermut.csv
+++ b/app/locale/fr_FR/Quadra_Cybermut.csv
@@ -55,3 +55,6 @@
 "Preference will be given to store language chosen by the user","La préférence sera donnée à la langue du magasin choisi par l'utilisateur"
 "Security key","Clé de sécurité"
 "Security key is priority on file key. Please keep it empty to use file key so.","La clé de sécurité est prioritaire sur la clé fichier. Veuillez donc conserver ce champ vide pour utiliser la clé fichier"
+"4.0 (Not released under production yet)","4.0 (Non disponible en production actuellement)"
+"Test/Debug mode will be restricted to these IP (IPv4 or IPv6)","Le mode de test & debug seront restreints aux IP ci-dessus (IPv4 ou IPv6)"
+"Test/Debug mode IP List","Liste d'IP pour Test/Debug"

--- a/modman
+++ b/modman
@@ -1,0 +1,6 @@
+app/code/community/Quadra/Cybermut						app/code/community/Quadra/Cybermut
+app/design/frontend/base/default/layout/cybermut.xml		app/design/frontend/base/default/layout/cybermut.xml
+app/design/frontend/base/default/template/cybermut		app/design/frontend/base/default/template/cybermut
+app/etc/modules/Quadra_Cybermut.xml						app/etc/modules/Quadra_Cybermut.xml
+app/locale/fr_FR/Quadra_Cybermut.csv						app/locale/fr_FR/Quadra_Cybermut.csv
+skin/frontend/base/default/images/media/cybermut			skin/frontend/base/default/images/media/cybermut


### PR DESCRIPTION
Hi,
Here are some updates You could merge into your project:
1. Adding the possibility to use the new V3 plain key instead of a file
2. Bug solved : it is now possible to delete the file key data
3. Bug solved : the debug_flag is now working properly
4. The version number (3.0....) is now entirely dynamic and not anymore hardcoded into the strings
5. Trim added to the TPE number, otherwise any space would break the protocol
6.  Adding a modman file
7. Adding an Test/Debug IP List to allow chosen IP to test orders on a live environment without interfering with customers' payments
8. Adding the version 4.0 to the version's list, given the CIC is working on it currently.